### PR TITLE
Support for relative step files and pre-existing IDs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 
 from setuptools import setup, find_packages
 
-with open('Readme.md') as f:
+with open('README.md') as f:
     readme = f.read()
 
 with open('LICENSE') as f:


### PR DESCRIPTION
Kaushik;
Thanks much for this project, it's really nice to have a command line tool for handling the app upload and task submission and monitoring. I got a test bcbio run going using this with only a couple of modifications. Happy to explain any of the small changes in more details. Thanks again.

- Allow specification of external workflows by relative
  paths to the base workflow.
- Enable support for SBG file IDs in input sample json, rather than
  local files. These get looked up by ID, rather than attempting to
  upload.
- Fix for setup.py finding the README